### PR TITLE
use amazon as amazon linux's platform_family name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,7 @@ default['yarn']['package'].tap do |package|
 
   package['repository']['uri'] = case node['platform_family']
                          when 'debian' then 'https://dl.yarnpkg.com/debian/'
-                         when 'rhel' then 'https://dl.yarnpkg.com/rpm/'
+                         when 'rhel', 'amazon' then 'https://dl.yarnpkg.com/rpm/'
                          end
   package['repository']['key'] = case node['platform_family']
                          when 'debian' then 'https://dl.yarnpkg.com/debian/pubkey.gpg'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ default['yarn']['package'].tap do |package|
                          end
   package['repository']['key'] = case node['platform_family']
                          when 'debian' then 'https://dl.yarnpkg.com/debian/pubkey.gpg'
-                         when 'rhel' then 'https://dl.yarnpkg.com/rpm/pubkey.gpg'
+                         when 'rhel', 'amazon' then 'https://dl.yarnpkg.com/rpm/pubkey.gpg'
                          end
   package['repository']['distribution'] = 'stable'
   package['repository']['components'] = %w(

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -23,7 +23,7 @@ when 'debian'
     components node['yarn']['package']['repository']['components']
     action :add
   end
-when 'rhel'
+when 'rhel', 'amazon'
   yum_repository 'yarn' do
     baseurl node['yarn']['package']['repository']['uri']
     gpgkey  node['yarn']['package']['repository']['key']


### PR DESCRIPTION
It seems that the platform_family name for amazon linux changed from `rhel` to `amazon` according to this link.

https://docs.chef.io/deprecations_ohai_amazon_linux.html